### PR TITLE
fix(mods): add EMI folder dependencies

### DIFF
--- a/mods/client/bro-know-my-emi-folder.pw.toml
+++ b/mods/client/bro-know-my-emi-folder.pw.toml
@@ -1,0 +1,13 @@
+name = "Bro Know My EMI Folder"
+filename = "bro-know-my-emi-folder-0.0.3+1.21.1.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "c7decc2e64abbe47cd51ac2ef5277c949f5c0c80"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8301196
+project-id = 1564728

--- a/mods/client/emi.pw.toml
+++ b/mods/client/emi.pw.toml
@@ -1,0 +1,13 @@
+name = "EMI"
+filename = "emi-1.1.24+1.21.1+neoforge.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "3fd494b37027dfbc7f78414d7cbf251c9eb6738a"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8081408
+project-id = 580555

--- a/mods/common/emi-ores.pw.toml
+++ b/mods/common/emi-ores.pw.toml
@@ -1,0 +1,13 @@
+name = "EMI Ores"
+filename = "emi_ores-1.3+1.21.1+neoforge.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "26e3f998295bae5178530d4bb217e824a2637121"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 8254306
+project-id = 974009


### PR DESCRIPTION
## Summary
- Add Bro Know My EMI Folder as a client-side mod metadata entry
- Add EMI as a client-side dependency
- Add EMI Ores as a common mod metadata entry

## Verification
- Started locally after adding the three mods
- pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\devtool.ps1 check
- install-files-headless synced 307 managed mods with 0 missing and 0 hash mismatches