### PR TITLE
chore(github): issue claim flow

### DIFF
--- a/.github/workflows/issue-claim.yml
+++ b/.github/workflows/issue-claim.yml
@@ -1,0 +1,64 @@
+name: Issue Claim
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  label-new-issues:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-claim label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['needs-claim'],
+            });
+
+  claim-issue:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Claim issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const user = context.payload.comment.user.login;
+            const body = context.payload.comment.body.trim();
+
+            if (issue.pull_request || body !== '/claim') {
+              core.info('Skipping non-issue comments and non-claim commands.');
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [user],
+            });
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              name: 'needs-claim',
+            }).catch(() => {});
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['claimed'],
+            });

--- a/docs/DevGuide.md
+++ b/docs/DevGuide.md
@@ -384,6 +384,21 @@ chore(bkmpw): add create mod metadata
 chore(bkmpw): refresh index
 ```
 
+## Issue 认领
+
+仓库的 issue 采用“先认领，再处理”的轻量流程，目的是避免多人同时重复开工。
+
+- 新 issue 默认应带 `needs-claim` 标签。
+- 开发者在 issue 下评论 `/claim` 表示要认领该任务。
+- 认领后由 GitHub Action 自动将 issue 分配给评论人，并把标签从 `needs-claim` 切换为 `claimed`。
+- 如果 issue 已经被认领，后续开发请优先在已分配的 issue 上继续，不要重复抢占同一任务。
+
+对应自动化定义在：
+
+```text
+.github/workflows/issue-claim.yml
+```
+
 ## 常用检查
 
 ```powershell


### PR DESCRIPTION
Adds the GitHub issue claim workflow and documents the process in DevGuide.

Commits:
- chore(github): add issue claim workflow
- docs(devguide): document issue claim flow

Note: `kubejs/server_scripts/jsconfig.json` and the other untracked files in the worktree were left untouched.