### PR TITLE
fix(kubejs): 修复损坏的 tag 元数据

### DIFF
--- a/kubejs/data/netherexp/tags/fluid/ectoplasm.json
+++ b/kubejs/data/netherexp/tags/fluid/ectoplasm.json
@@ -1,7 +1,7 @@
 {
   "replace": true,
   "values": [
-    "netherexp:ectoplasm_source",
-    "netherexp:ectoplasm_flowing"
+    "netherexp:ectoplasm",
+    "netherexp:flowing_ectoplasm"
   ]
 }

--- a/kubejs/data/sereneseasons/tags/block/autumn_crops.json
+++ b/kubejs/data/sereneseasons/tags/block/autumn_crops.json
@@ -1,0 +1,11 @@
+{
+  "replace": true,
+  "values": [
+    "dumplings_delight:celery",
+    "dumplings_delight:chinese_cabbages",
+    "dumplings_delight:fennel",
+    "dumplings_delight:garlic",
+    "dumplings_delight:garlic_chive",
+    "dumplings_delight:greenonion"
+  ]
+}

--- a/kubejs/data/sereneseasons/tags/item/autumn_crops.json
+++ b/kubejs/data/sereneseasons/tags/item/autumn_crops.json
@@ -1,0 +1,14 @@
+{
+  "replace": true,
+  "values": [
+    {
+      "id": "dumplings_delight:celery_seeds",
+      "required": false
+    },
+    "dumplings_delight:chinese_cabbage_seeds",
+    "dumplings_delight:fennel_seeds",
+    "dumplings_delight:garlic",
+    "dumplings_delight:garlic_chive_seeds",
+    "dumplings_delight:greenonion"
+  ]
+}

--- a/kubejs/startup_scripts/global_data.js
+++ b/kubejs/startup_scripts/global_data.js
@@ -44,6 +44,6 @@ global.INFINITE_SOURCE_FLUIDS = [
   'createdelightcore:molten_quartz_vibrant_glass',
   'createdelightcore:egg_yolk',
   'createdelightcore:vinegar',
-  'netherexp:ectoplasm_source',
+  'netherexp:ectoplasm',
   'the_bumblezone:sugar_water_still',
 ];

--- a/mods/common/lmft.pw.toml
+++ b/mods/common/lmft.pw.toml
@@ -1,0 +1,13 @@
+name = "Load My F***ing Tags"
+filename = "lmft-1.0.4+1.21-neoforge.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "5eaff991e132659b9c04041da3a54d9c0dec2c3f"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 5425796
+project-id = 656346


### PR DESCRIPTION
## 概要
- 添加 LMFT 元数据，用于在测试时暴露损坏的 tag 条目
- 修正 Nether Expansion 的 ectoplasm 流体 tag ID，并同步 KubeJS 无限流体列表
- 覆盖 Dumplings Delight Rewrapped 的 Serene Seasons 秋季作物 tag，规避错误/缺失的 celery seed 条目

## 验证
- `./devtool.bat refresh`
- `./devtool.bat check`
- 已启动客户端并进入世界
- 游戏内执行 `/reload` 后确认 `sereneseasons:autumn_crops` 和 `dumplings_delight:celery_seeds` 不再出现在 tag 错误中

## 后续
- Nether Expansion 仍自带一个 `minecraft:spawns_warm_variant_frogs` tag 文件，内容只有 `remove` 而没有 `values`；KubeJS 覆盖无法阻止该 mod 数据包自身解析时报错。因此本 PR 不修改该文件，后续单独跟进[上游问题issue](https://github.com/ThatJadenXgamer/Jadens-Nether-Expansion/issues/293)。