### PR TITLE
修复 FancyMenu 加载地形文案重影

### DIFF
--- a/config/fancymenu/customizablemenus.txt
+++ b/config/fancymenu/customizablemenus.txt
@@ -3,6 +3,9 @@ type = customizablemenus
 de.keksuccino.drippyloadingscreen.customization.DrippyOverlayScreen {
 }
 
+net.minecraft.client.gui.screens.ReceivingLevelScreen {
+}
+
 net.minecraft.client.gui.screens.TitleScreen {
 }
 

--- a/kubejs/assets/minecraft/lang/zh_cn.json
+++ b/kubejs/assets/minecraft/lang/zh_cn.json
@@ -1,3 +1,0 @@
-{
-  "multiplayer.downloadingTerrain": ""
-}


### PR DESCRIPTION
## Summary
- Remove the temporary multiplayer.downloadingTerrain translation override from #75.
- Register ReceivingLevelScreen as a FancyMenu customizable screen instead.
- This lets FancyMenu suppress the vanilla centered text and keep its own downloading_terrain widget, avoiding duplicated/ghosted text without hiding the message entirely.

## Verification
- Tested locally: adding ReceivingLevelScreen to customizablemenus.txt removes the duplicated loading terrain text.