### PR TITLE
mod&fix: 升级节气到 0.13.9.1解决开启光影崩溃问题

### DIFF
--- a/config/eclipticseasons-common.toml
+++ b/config/eclipticseasons-common.toml
@@ -36,10 +36,12 @@
 	#Warning: May cause day-counter or calendar conflicts with other mods.
 	RealWorldSolarTerms = false
 	#Shifts the displayed month index. This does NOT affect internal solar term calculations.
-	#Range: -11 ~ 11
+	# Default: 1
+	# Range: -11 ~ 11
 	MonthOffset = 1
 	#Shifts the calendar day relative to solar terms. Example: 2 means solar day 0 appears as the 3rd day of the month.
-	#Range: -64 ~ 64
+	# Default: 2
+	# Range: -64 ~ 64
 	DayOffset = 2
 
 [Weather]
@@ -47,8 +49,6 @@
 	UseSolarWeather = true
 	#Force initialize weather and snow states when the mod or world is first loaded.
 	ShouldInitWeather = false
-	#Force initialize snow states for extreme cold biomes when the mod or world is first loaded.
-	ShouldInitSnowDepthForExtremeColdBiomes = true
 	#Adjusts the spread rate of atmospheric snow overlays across the ground.
 	# Default: 1.0
 	# Range: 0.0 ~ 20.0
@@ -62,11 +62,15 @@
 	#Disable rain/snow in biomes with no natural precipitation (e.g., Deserts).
 	NoRainInDeserts = false
 	#Adjust the overall frequency of rain.
-	#Range: 0 ~ 1000
+	# Default: 120
+	# Range: 0 ~ 1000
 	RainChanceMultiplier = 120
 	#Adjust the overall frequency of thunder.
-	#Range: 0 ~ 1000
+	# Default: 80
+	# Range: 0 ~ 1000
 	ThunderChanceMultiplier = 80
+	#Force initialize snow states for extreme cold biomes when the mod or world is first loaded.
+	ShouldInitSnowForExtremeColdBiomes = true
 
 #This module governs how seasonal temperature shifts affect the physical world and the player.
 [Temperature]
@@ -131,14 +135,16 @@
 	#Bone meal may fail under unsuitable growing conditions.
 	RestrictBoneMeal = true
 	#The duration required for the Prayer Ritual (relative to one Solar Term).
-	#Range: 1.0E-5 ~ 5000.0
+	# Default: 0.15
+	# Range: 1.0E-5 ~ 5000.0
 	SeasonalRitualTimeCost = 0.15
 	#Uses the classic chat-message display for the growth detector instead of the new in-world UI.
 	GrowthDetectorClassicMode = false
 	#Whether Wandering Traders can sell Seasonal Greenhouse Essence.
 	WanderingTraderSellsGreenhouseEssence = true
 	#The effective radius of the 'Humid Tank' block.
-	#Range: 2.0 ~ 16.0
+	# Default: 4.5
+	# Range: 2.0 ~ 16.0
 	HumidityTankRange = 4.5
 
 [Animal]
@@ -212,8 +218,6 @@
 	FixBiomePrecipitation = true
 	#Show crop growth diagnostics in Jade or TOP.
 	ShowCropGrowthInfoInProbe = true
-	#Enables winter-themed Level of Detail (LOD) textures for Distant Horizons to ensure visual consistency at long distances.
-	DistantHorizonsWinterLOD = false
 
 [Debug]
 	#Force using server synchronized config when joining a multiplayer server.

--- a/config/eclipticseasons-common.toml
+++ b/config/eclipticseasons-common.toml
@@ -35,24 +35,20 @@
 	#Sync in-game seasons with the real-world date.
 	#Warning: May cause day-counter or calendar conflicts with other mods.
 	RealWorldSolarTerms = false
+	#Shifts the displayed month index. This does NOT affect internal solar term calculations.
+	#Range: -11 ~ 11
+	MonthOffset = 1
+	#Shifts the calendar day relative to solar terms. Example: 2 means solar day 0 appears as the 3rd day of the month.
+	#Range: -64 ~ 64
+	DayOffset = 2
 
 [Weather]
 	#Enable localized weather patterns where rain or sun is determined per-biome.
 	UseSolarWeather = true
-	#Disable rain/snow in biomes with no natural precipitation (e.g., Deserts).
-	NotRainInDesert = false
 	#Force initialize weather and snow states when the mod or world is first loaded.
 	ShouldInitWeather = false
 	#Force initialize snow states for extreme cold biomes when the mod or world is first loaded.
-	ShouldInitSnowForExtremeColdBiomes = true
-	#Adjust the overall frequency of rain.
-	# Default: 40
-	# Range: 0 ~ 1000
-	RainChancePercentMultiplier = 40
-	#Adjust the overall frequency of thunder.
-	# Default: 20
-	# Range: 0 ~ 1000
-	ThunderChancePercentMultiplier = 20
+	ShouldInitSnowDepthForExtremeColdBiomes = true
 	#Adjusts the spread rate of atmospheric snow overlays across the ground.
 	# Default: 1.0
 	# Range: 0.0 ~ 20.0
@@ -63,6 +59,14 @@
 	SnowMeltSpeedMultiplier = 1.0
 	#Automatically reset weather to clear after the player wakes up from a bed.
 	ClearAfterSleep = false
+	#Disable rain/snow in biomes with no natural precipitation (e.g., Deserts).
+	NoRainInDeserts = false
+	#Adjust the overall frequency of rain.
+	#Range: 0 ~ 1000
+	RainChanceMultiplier = 120
+	#Adjust the overall frequency of thunder.
+	#Range: 0 ~ 1000
+	ThunderChanceMultiplier = 80
 
 #This module governs how seasonal temperature shifts affect the physical world and the player.
 [Temperature]
@@ -78,9 +82,9 @@
 	HeatStroke = false
 
 [Crop]
-	#Restrict plant growth based on their compatible seasons or humidity.
+	#Restrict plant growth based on their compatible seasons.
 	EnableSeasonalCrop = true
-	#Restrict plant growth based on local soil/environmental humidity.
+	#Restrict plant growth based on local environmental humidity.
 	EnableCropHumidityControl = true
 	#Smooths out humidity changes between different areas or time periods.
 	CropHumidityTransition = true
@@ -124,10 +128,18 @@
 	# Default: 500
 	# Range: > 5
 	SeasonalPrayerRitualCropBonusReduction = 500
+	#Bone meal may fail under unsuitable growing conditions.
+	RestrictBoneMeal = true
 	#The duration required for the Prayer Ritual (relative to one Solar Term).
-	# Default: 2.0
-	# Range: 1.0E-5 ~ 5000.0
-	SeasonalPrayerRitualTimeCost = 2.0
+	#Range: 1.0E-5 ~ 5000.0
+	SeasonalRitualTimeCost = 0.15
+	#Uses the classic chat-message display for the growth detector instead of the new in-world UI.
+	GrowthDetectorClassicMode = false
+	#Whether Wandering Traders can sell Seasonal Greenhouse Essence.
+	WanderingTraderSellsGreenhouseEssence = true
+	#The effective radius of the 'Humid Tank' block.
+	#Range: 2.0 ~ 16.0
+	HumidityTankRange = 4.5
 
 [Animal]
 	#Limit animal breeding to their natural, compatible seasons.
@@ -153,8 +165,10 @@
 	SeasonCoreAffectsAnimals = true
 
 [Map]
-	#Synchronize map colors to reflect atmospheric snow overlays.
-	ChangeMapColor = true
+	#Synchronize all map color rendering with visual snow overlays. May affect compatibility with other mods.
+	ChangeMapColorIfSnowy = false
+	#Only adjust map item colors to reflect visual snow overlays. Safer for mod compatibility.
+	ChangeMapColorMapItem = true
 
 #Snow overlays are visual, atmospheric effects and are distinct from physical snow blocks.
 [Snow]
@@ -196,11 +210,10 @@
 	ModsWithoutSereneSeasonBasedHumidity = []
 	#Intercepts raw biome precipitation queries to ensure small biomes (like rivers) do not disrupt large-scale weather logic.
 	FixBiomePrecipitation = true
-	#Determines global weather state based on player locations when external mods bypass our API.
-	#This represents the weighted threshold required to trigger a specific weather condition.
-	# Default: 0.5
-	# Range: 0.0 ~ 1.0
-	WeatherVotePercent = 0.5
+	#Show crop growth diagnostics in Jade or TOP.
+	ShowCropGrowthInfoInProbe = true
+	#Enables winter-themed Level of Detail (LOD) textures for Distant Horizons to ensure visual consistency at long distances.
+	DistantHorizonsWinterLOD = false
 
 [Debug]
 	#Force using server synchronized config when joining a multiplayer server.
@@ -220,8 +233,6 @@
 	DisableIceOrSnowCauldron = false
 
 [Resource]
-	#Synchronizes weather states across all Overworld biomes, ensuring global rainfall.
-	RainTogether = false
 	#Synchronizes the snowfall schedule for all Overworld biomes.
 	SnowTogether = false
 	#Aligns snowfall schedules based on three broad climate zones (Warm, Temperate, and Cold) instead of per-biome.
@@ -229,4 +240,4 @@
 	#Enforces original Vanilla temperature and precipitation settings to prevent other mods from creating extreme environmental values.
 	VanillaBiomeClimateSettings = true
 	#When enabled, rivers are no longer treated as ignored climate zones. This reduces performance overhead but may result in less natural weather transitions near riverbanks.
-	NotIgnoreRiver = false
+	IndependentRiverWeather = true

--- a/kubejs/config/createdelight_pack_integrity_expected.json
+++ b/kubejs/config/createdelight_pack_integrity_expected.json
@@ -1810,7 +1810,7 @@
     {
       "side": "common",
       "metadata": "mods/common/ecliptic-seasons.pw.toml",
-      "filename": "EclipticSeasons-1.21.1-neoforge-0.12.18.13.jar",
+      "filename": "EclipticSeasons-1.21.1-neoforge-0.13.9.1.jar",
       "modIds": [
         "eclipticseasons"
       ]

--- a/mods/common/ecliptic-seasons.pw.toml
+++ b/mods/common/ecliptic-seasons.pw.toml
@@ -1,13 +1,13 @@
 name = "Ecliptic Seasons"
-filename = "EclipticSeasons-1.21.1-neoforge-0.12.18.13.jar"
+filename = "EclipticSeasons-1.21.1-neoforge-0.13.9.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "cfdc5d2a526bd3792f1b1f33074ea89c5175f8a0"
+hash = "79ea75c18219a7056f42a8968b9b0b8c0602d835"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7949191
+file-id = 8350852
 project-id = 1118306


### PR DESCRIPTION
## 变更内容

- 将 Ecliptic Seasons 升级到 1.21.1 NeoForge 0.13.9.1
- 按上游 Create-Delight-Remake#1834 迁移节气 0.13.x 配置项
- 同步整合包完整性期望清单中的节气 jar 文件名

## 验证

- devtool.bat check
- devtool.bat refresh
- devtool.bat check

## 说明

已按要求忽略上游 PR 中 CDC submodule / core jar 相关变更。本仓库当前没有对应的 MBD2 sprinkler 脚本，FTB 任务章节也为空，因此未移植无本地落点的任务与脚本改动。