### PR TITLE
WIP: 添加机械动力航空学

### DIFF
--- a/kubejs/config/createdelight_pack_integrity_expected.json
+++ b/kubejs/config/createdelight_pack_integrity_expected.json
@@ -13,6 +13,8 @@
       "ae2omnicells",
       "ae2wtlib",
       "ae2wtlib_api",
+      "aeronautics",
+      "aeronautics_bundled",
       "alexscaves",
       "alexsdelight",
       "alexsmobs",
@@ -277,6 +279,7 @@
       "northstar",
       "northstar_curios_compat",
       "observable",
+      "offroad",
       "owo",
       "oworld2create",
       "packetfixer",
@@ -301,6 +304,7 @@
       "resourcefullib",
       "rhino",
       "runiclib",
+      "sable",
       "sablecompanion",
       "schematicanon_processing_pattern",
       "searchables",
@@ -308,6 +312,7 @@
       "silentsdelight",
       "simplebackups",
       "simplehats",
+      "simulated",
       "smartbrainlib",
       "someassemblyrequired",
       "sophisticatedbackpacks",
@@ -337,6 +342,7 @@
       "travelerstitles",
       "txnilib",
       "uranus",
+      "veil",
       "vinery",
       "vintagedelight",
       "vintageimprovements",
@@ -1618,6 +1624,17 @@
     },
     {
       "side": "common",
+      "metadata": "mods/common/create-aeronautics.pw.toml",
+      "filename": "create-aeronautics-bundled-1.21.1-1.3.0.jar",
+      "modIds": [
+        "aeronautics",
+        "aeronautics_bundled",
+        "offroad",
+        "simulated"
+      ]
+    },
+    {
+      "side": "common",
       "metadata": "mods/common/create-dragons-plus.pw.toml",
       "filename": "CreateDragonsPlus-1.11.2b.jar",
       "modIds": [
@@ -2645,6 +2662,16 @@
       "filename": "rhino-2101.2.7-build.81.jar",
       "modIds": [
         "rhino"
+      ]
+    },
+    {
+      "side": "common",
+      "metadata": "mods/common/sable.pw.toml",
+      "filename": "sable-neoforge-1.21.1-2.0.3.jar",
+      "modIds": [
+        "sable",
+        "sablecompanion",
+        "veil"
       ]
     },
     {

--- a/mods/common/create-aeronautics.pw.toml
+++ b/mods/common/create-aeronautics.pw.toml
@@ -1,0 +1,14 @@
+name = "Create Aeronautics"
+filename = "create-aeronautics-bundled-1.21.1-1.3.0.jar"
+side = "both"
+
+[download]
+url = "https://edge.forgecdn.net/files/8240/058/create-aeronautics-bundled-1.21.1-1.3.0.jar"
+hash-format = "sha256"
+hash = "482c90e0e6fe72f33fe7abb079e5fda581cd660ee53c38c44448a64283e1044c"
+mode = "url"
+
+[update]
+[update.curseforge]
+file-id = 8240058
+project-id = 676721

--- a/mods/common/sable.pw.toml
+++ b/mods/common/sable.pw.toml
@@ -1,0 +1,14 @@
+name = "Sable"
+filename = "sable-neoforge-1.21.1-2.0.3.jar"
+side = "both"
+
+[download]
+url = "https://edge.forgecdn.net/files/8263/584/sable-neoforge-1.21.1-2.0.3.jar"
+hash-format = "sha256"
+hash = "da6c3b66238586603d1dcaa2afb012d36815fbce0a2d5938fbb2936701d42279"
+mode = "url"
+
+[update]
+[update.curseforge]
+file-id = 8263584
+project-id = 1312371

--- a/scripts/pack-integrity.mjs
+++ b/scripts/pack-integrity.mjs
@@ -186,6 +186,7 @@ function getNestedModIdsFromArchive(zip, depth = 0) {
   for (const entry of zip.entries) {
     if (!entry.name.toLowerCase().endsWith('.jar')) continue;
     const nestedZip = new ZipArchive(zip.readEntry(entry));
+    if (isKnownNonRuntimeEmbeddedJar(nestedZip)) continue;
     for (const modId of getModIdsFromArchive(nestedZip)) {
       if (!NON_RUNTIME_EMBEDDED_MOD_IDS.has(modId)) addUnique(ids, modId);
     }
@@ -203,6 +204,11 @@ function hasAnyEntry(zip, entryNames) {
 
 function isKnownNonRuntimeJar(zip) {
   return hasAnyEntry(zip, ['META-INF/services/cpw.mods.modlauncher.api.ITransformationService']);
+}
+
+function isKnownNonRuntimeEmbeddedJar(zip) {
+  const manifest = zip.readText('META-INF/MANIFEST.MF') ?? '';
+  return isKnownNonRuntimeJar(zip) || /^FMLModType:\s*GAMELIBRARY\s*$/im.test(manifest);
 }
 
 function isKnownNonModJar(zip) {


### PR DESCRIPTION
## 变更内容

- 添加 Create Aeronautics 1.21.1-1.3.0 的 bkmpw 元数据
- 添加 Aeronautics 运行所需的 Sable 元数据
- 更新整合包完整性期望清单
- 调整完整性清单生成逻辑，忽略嵌套 `FMLModType: GAMELIBRARY`，避免 `sable_rapier` 被误计为运行时 mod

## 验证

- `devtool.bat refresh`
- `devtool.bat generate-integrity-manifest`
- `devtool.bat check`