### PR TITLE
chore: 忽略 CocoIndex 索引

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ server/*.tmp
 .probe
 kubejs/config/probe-settings.json
 kubejs/config/web_server.json
+# CocoIndex Code (ccc)
+/.cocoindex_code/


### PR DESCRIPTION
忽略本地 CocoIndex 生成的 .cocoindex_code 目录，避免将索引产物纳入版本控制。